### PR TITLE
FIX: promotion bug - undesired check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hs_err_pid*
 
 # Eclipse
 .settings/
+/bin/

--- a/src/chess/ChessMatch.java
+++ b/src/chess/ChessMatch.java
@@ -133,6 +133,8 @@ public class ChessMatch {
 		board.placePiece(newPiece, pos);
 		piecesOnTheBoard.add(newPiece);
 		
+		check = (testCheck(opponent(newPiece.getColor()))) ? true : false;
+		
 		return newPiece;
 	}
 	


### PR DESCRIPTION
If a black king is sitting on row 8 and a paw is promoted to a bishop, and there's no piece between these two, the unfixed code would evaluate to a check situation. The following images show this 

Initially, we have this situation:
![Screenshot from 2024-08-15 21-27-45](https://github.com/user-attachments/assets/85bfde42-688e-4b86-a4d3-e291705f088e)

After promoting the White H7 Pawn to a White H8 Bishop, the blacks would end in check:
![Screenshot from 2024-08-15 21-28-09](https://github.com/user-attachments/assets/1245fc73-8bcb-4b3e-9b85-b8bd5211124a)

But that's a bug! The White Bishop cannot check the Black King on that situation.

This commit fix this bug.